### PR TITLE
Fix wording in error messages referencing SQL Server instead of MariaDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "MariaDB",
-    "version": "0.1.23",
-    "versionDate": "2022-07-29",
+    "version": "0.1.24",
+    "versionDate": "2022-09-16",
     "author": "hackolade",
     "engines": {
         "hackolade": "6.1.2",

--- a/reverse_engineering/config.json
+++ b/reverse_engineering/config.json
@@ -1,7 +1,7 @@
 {
 	"errors": {
-		"NO_DATABASES": "There is no databases in SQL Server instance",
-		"WRONG_CONNECTION": "Can not connect to SQL Server instance"
+		"NO_DATABASES": "There is no databases in MariaDB instance",
+		"WRONG_CONNECTION": "Can not connect to MariaDB instance"
 	},
 	"defaultDdlType": "mariadb",
 	"excludeDocKind": ["id"],

--- a/reverse_engineering/package.json
+++ b/reverse_engineering/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "MSSQLServer",
+  "name": "MariaDB",
   "version": "1.0.0",
   "description": "",
   "author": "Hackolade",


### PR DESCRIPTION
# Context

When working of plugin creation for MySQL,  I noticed some leftovers.

This PR fixes this discrepancy with the correct naming.
