### PR TITLE
HCK-8002: remove trailing comma before last deactivated column

### DIFF
--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -17,7 +17,6 @@ module.exports = (baseProvider, options, app) => {
 		clean,
 	} = app.require('@hackolade/ddl-fe-utils').general;
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
-	const { joinActivatedAndDeactivatedStatements } = app.require('@hackolade/ddl-fe-utils');
 	const { decorateDefault, decorateType, canBeNational, getSign, canHaveAutoIncrement } =
 		require('./ddlHelpers/columnDefinitionHelper')(_, wrap);
 	const { getTableName, getTableOptions, getPartitions, getViewData, getCharacteristics, escapeQuotes, wrapInTics } =
@@ -155,21 +154,10 @@ module.exports = (baseProvider, options, app) => {
 
 			const dividedForeignKeys = divideIntoActivatedAndDeactivated(foreignKeyConstraints, key => key.statement);
 			const foreignKeyConstraintsString = generateConstraintsString(dividedForeignKeys, isActivated);
-			const columnStatementDtos = columns.map(column => {
-				return {
-					statement: column,
-					isActivated: !column.startsWith('--'),
-				};
-			});
-			const columnDefinitions = joinActivatedAndDeactivatedStatements({
-				statementDtos: columnStatementDtos,
-				delimiter: ',',
-				indent: '\n\t',
-			});
 
 			return assignTemplates(templates.createTable, {
 				name: tableName,
-				column_definitions: columnDefinitions,
+				column_definitions: columns.join(',\n\t'),
 				selectStatement: selectStatement ? ` ${selectStatement}` : '',
 				orReplace: orReplaceTable,
 				temporary: temporaryTable,

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -4,6 +4,7 @@ const templates = require('./templates');
 const { HydratedColumn } = require('./types/hydratedColumn');
 const { ColumnDefinition } = require('./types/columnDefinition');
 const { KeyJsonSchema } = require('./types/keyJsonSchema');
+const { joinActivatedAndDeactivatedStatements } = require('../utils/joinActivatedAndDeactivatedStatements');
 
 module.exports = (baseProvider, options, app) => {
 	const _ = app.require('lodash');
@@ -154,10 +155,11 @@ module.exports = (baseProvider, options, app) => {
 
 			const dividedForeignKeys = divideIntoActivatedAndDeactivated(foreignKeyConstraints, key => key.statement);
 			const foreignKeyConstraintsString = generateConstraintsString(dividedForeignKeys, isActivated);
+			const columnStatements = joinActivatedAndDeactivatedStatements({ statements: columns, indent: '\n\t' });
 
 			return assignTemplates(templates.createTable, {
 				name: tableName,
-				column_definitions: columns.join(',\n\t'),
+				column_definitions: columnStatements,
 				selectStatement: selectStatement ? ` ${selectStatement}` : '',
 				orReplace: orReplaceTable,
 				temporary: temporaryTable,

--- a/forward_engineering/ddlProvider/ddlProvider.js
+++ b/forward_engineering/ddlProvider/ddlProvider.js
@@ -17,6 +17,7 @@ module.exports = (baseProvider, options, app) => {
 		clean,
 	} = app.require('@hackolade/ddl-fe-utils').general;
 	const { assignTemplates } = app.require('@hackolade/ddl-fe-utils');
+	const { joinActivatedAndDeactivatedStatements } = app.require('@hackolade/ddl-fe-utils');
 	const { decorateDefault, decorateType, canBeNational, getSign, canHaveAutoIncrement } =
 		require('./ddlHelpers/columnDefinitionHelper')(_, wrap);
 	const { getTableName, getTableOptions, getPartitions, getViewData, getCharacteristics, escapeQuotes, wrapInTics } =
@@ -154,10 +155,21 @@ module.exports = (baseProvider, options, app) => {
 
 			const dividedForeignKeys = divideIntoActivatedAndDeactivated(foreignKeyConstraints, key => key.statement);
 			const foreignKeyConstraintsString = generateConstraintsString(dividedForeignKeys, isActivated);
+			const columnStatementDtos = columns.map(column => {
+				return {
+					statement: column,
+					isActivated: !column.startsWith('--'),
+				};
+			});
+			const columnDefinitions = joinActivatedAndDeactivatedStatements({
+				statementDtos: columnStatementDtos,
+				delimiter: ',',
+				indent: '\n\t',
+			});
 
 			return assignTemplates(templates.createTable, {
 				name: tableName,
-				column_definitions: columns.join(',\n\t'),
+				column_definitions: columnDefinitions,
 				selectStatement: selectStatement ? ` ${selectStatement}` : '',
 				orReplace: orReplaceTable,
 				temporary: temporaryTable,

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -11,8 +11,12 @@ const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement
 	const isLastStatement = index === numberOfStatements - 1;
 	const isLastActivatedStatement = index === lastIndexOfActivatedStatement;
 
-	if (isLastStatement || isLastActivatedStatement) {
+	if (isLastStatement) {
 		return '';
+	}
+
+	if (isLastActivatedStatement) {
+		return ' --' + delimiter;
 	}
 
 	return delimiter;

--- a/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
+++ b/forward_engineering/utils/joinActivatedAndDeactivatedStatements.js
@@ -1,0 +1,49 @@
+/**
+ * @param {{
+* index: number;
+* numberOfStatements: number;
+* lastIndexOfActivatedStatement: number;
+* delimiter: string;
+* }}
+* @return {string}
+* */
+const getDelimiter = ({ index, numberOfStatements, lastIndexOfActivatedStatement, delimiter }) => {
+	const isLastStatement = index === numberOfStatements - 1;
+	const isLastActivatedStatement = index === lastIndexOfActivatedStatement;
+
+	if (isLastStatement || isLastActivatedStatement) {
+		return '';
+	}
+
+	return delimiter;
+};
+
+/**
+* @param {{
+* statements?: string[];
+* delimiter?: string;
+* indent?: string;
+* }}
+* @return {string}
+* */
+const joinActivatedAndDeactivatedStatements = ({ statements = [], delimiter = ',', indent = '\n' }) => {
+	const lastIndexOfActivatedStatement = statements.findLastIndex(statement => !statement.startsWith('--'));
+	const numberOfStatements = statements.length;
+
+	return statements
+		.map((statement, index) => {
+			const currentDelimiter = getDelimiter({
+				index,
+				numberOfStatements,
+				lastIndexOfActivatedStatement,
+				delimiter,
+			});
+
+			return statement + currentDelimiter;
+		})
+		.join(indent);
+};
+
+module.exports = {
+	joinActivatedAndDeactivatedStatements,
+};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8002" title="HCK-8002" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-8002</a>  [MariaDB]: DDL script is not valid when the last attribute is commented in Table
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
