### PR TITLE
HCK-9128: Handle indexes without name in MariaDB

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -1924,7 +1924,7 @@ making sure that you maintain a proper JSON format.
 					{
 						"propertyName": "Name",
 						"propertyKeyword": "indxName",
-						"propertyTooltip": "Optional, if not specified an automatic name will be assigned. Index name are needed to drop indexes and appear in error messages when a constraint is violated.",
+						"propertyTooltip": "",
 						"propertyType": "text",
 						"validation": {
 							"required": true
@@ -1965,7 +1965,11 @@ making sure that you maintain a proper JSON format.
 						"propertyKeyword": "indxKey",
 						"propertyType": "fieldList",
 						"template": "orderedList",
-						"attributeList": ["", "ASC", "DESC"]
+						"attributeList": ["", "ASC", "DESC"],
+						"validation": {
+							"required": true,
+							"minLength": 1
+						}
 					},
 					{
 						"propertyName": "Wait",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-9128" title="HCK-9128" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-9128</a>  Handle indexes without name in all SQL-like targets, depending whether name is mandatory or not
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated validation of required fields in the "Create Index" script
- index name is required
- columns are required