### PR TITLE
HCK-10442: add adapter to properly convert hasMaxLength property

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -120,6 +120,15 @@
 			},
 			{
 				"from": {
+					"type": "nvarchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 21844
+				}
+			},
+			{
+				"from": {
 					"type": "binary",
 					"hasMaxLength": true
 				},

--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -108,6 +108,24 @@
 				"to": {
 					"mode": "point"
 				}
+			},
+			{
+				"from": {
+					"type": "varchar",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 21844
+				}
+			},
+			{
+				"from": {
+					"type": "binary",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 21844
+				}
 			}
 		]
 	},

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -1,0 +1,59 @@
+/**
+ *
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+ {
+	"modify": {
+		"field": [
+			{
+				"from": {
+					"mode": "varchar",
+					"length": 21844
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"mode": "blob",
+					"length": 21844
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			}
+		]
+	}
+}

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -38,7 +38,7 @@
 		"field": [
 			{
 				"from": {
-					"mode": "varchar",
+					"childType": "char",
 					"length": 21844
 				},
 				"to": {
@@ -47,7 +47,7 @@
 			},
 			{
 				"from": {
-					"mode": "blob",
+					"mode": "varbinary",
 					"length": 21844
 				},
 				"to": {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10442" title="HCK-10442" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10442</a>  Implement max length mapping for RDBMS-like database targets (cross-target conversion)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added adapter to properly convert the hasMaxLength property