### PR TITLE
HCK-10529: updated adapter config to properly handle hasmaxLength on char

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -120,6 +120,16 @@
 			},
 			{
 				"from": {
+					"type": "varchar",
+					"mode": "char",
+					"hasMaxLength": true
+				},
+				"to": {
+					"length": 255
+				}
+			},
+			{
+				"from": {
 					"type": "nvarchar",
 					"hasMaxLength": true
 				},

--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -39,7 +39,18 @@
 			{
 				"from": {
 					"childType": "char",
+					"mode": "varchar",
 					"length": 21844
+				},
+				"to": {
+					"hasMaxLength": true
+				}
+			},
+			{
+				"from": {
+					"childType": "char",
+					"mode": "char",
+					"length": 255
 				},
 				"to": {
 					"hasMaxLength": true


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10529" title="HCK-10529" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10529</a>  [MariaDB/MySQL] char datatype with max length incorrect derived/converted from/to Poly
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Updated adapter config to properly handle hasmaxLength on char