### PR TITLE
HCK-10649: change adapter approach to preserve varchar length as 21844 instead of 255

### DIFF
--- a/polyglot/adapter.json
+++ b/polyglot/adapter.json
@@ -115,17 +115,17 @@
 					"hasMaxLength": true
 				},
 				"to": {
-					"length": 255
+					"length": 21844
 				}
 			},
 			{
 				"from": {
 					"type": "varchar",
-					"mode": "character",
+					"mode": "char",
 					"hasMaxLength": true
 				},
 				"to": {
-					"length": 21844
+					"length": 255
 				}
 			},
 			{


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10649" title="HCK-10649" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10649</a>  [MariaDB]+[MySQL] Regression: varchar with MAX length RE from PDM with the max length of char
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Changed adapter approach to preserve varchar length instead of 255